### PR TITLE
Drop deprecated metainformation from gemfile

### DIFF
--- a/rodauth.gemspec
+++ b/rodauth.gemspec
@@ -4,7 +4,6 @@ Gem::Specification.new do |s|
   s.name = 'rodauth'
   s.version = Rodauth.version
   s.platform = Gem::Platform::RUBY
-  s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc", "CHANGELOG", "MIT-LICENSE"] + Dir["doc/*.rdoc"] + Dir['doc/release_notes/*.txt']
   s.rdoc_options += ["--quiet", "--line-numbers", "--inline-source", '--title', 'Rodauth: Authentication and Account Management Framework for Rack Applications', '--main', 'README.rdoc']
   s.license = "MIT"


### PR DESCRIPTION
```
Fetching gem metadata from https://rubygems.org/.......
Fetching https://github.com/kgorin/rodauth.git
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /usr/local/bundle/bundler/gems/rodauth-cae17174b711/rodauth.gemspec:7.
```